### PR TITLE
Proof of Concept: Electron support

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,12 +34,14 @@
     "playwright": "=1.7.0-next.1607022026758"
   },
   "devDependencies": {
-    "folio": "^0.3.16",
     "css-loader": "^4.3.0",
+    "electron": "^11.0.3",
     "file-loader": "^6.1.0",
+    "folio": "^0.3.16",
     "html-webpack-plugin": "^4.4.1",
     "monaco-editor": "^0.20.0",
     "pkg": "^4.4.9",
+    "playwright-electron": "^0.5.0",
     "style-loader": "^1.2.1",
     "ts-loader": "^8.0.3",
     "typescript": "^4.0.2",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -362,15 +362,23 @@ async function codegen(options: Options, url: string | undefined, target: string
     browserName = 'electron';
     launchOptions = {};
     contextOptions = {};
-    // TODO: register some sort of close handler to exit the script when electron exits. for some reason page close isn't firing.
 
-    // for some reason, we need to launch something else in order to get left mouse clicks to reach our application. wtf?
-    await playwright.chromium.launch();
+    // wait for the main window to finish loading.
+    await new Promise<void>(resolve => {
+      app.on('window', (page) => {
+        if(!page.url().startsWith('devtools://')) {
+          resolve();
+        }
+      })
+    });
 
-    // TODO: handle waiting for the last window to close.
+    // once all windows have closed, exit.
     app.on('window', page => {
       page.on('close', () => {
-        app.close().catch( x => null);
+        if(!app.windows().length)
+        {
+          app.close().catch( x => null);
+        }
       });
     });
   } else {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -366,6 +366,13 @@ async function codegen(options: Options, url: string | undefined, target: string
 
     // for some reason, we need to launch something else in order to get left mouse clicks to reach our application. wtf?
     await playwright.chromium.launch();
+
+    // TODO: handle waiting for the last window to close.
+    app.on('window', page => {
+      page.on('close', () => {
+        app.close().catch( x => null);
+      });
+    });
   } else {
     const launch = await launchContext(options, false);
     context = launch.context;

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -22,6 +22,7 @@ import * as os from 'os';
 import * as fs from 'fs';
 import * as playwright from 'playwright';
 import { Browser, BrowserContext, Page } from 'playwright';
+import { electron } from 'playwright-electron'
 import { ScriptController } from './scriptController';
 import { OutputMultiplexer, TerminalOutput, FileOutput } from './codegen/outputs'
 import { CodeGenerator, CodeGeneratorOutput } from './codegen/codeGenerator';
@@ -82,8 +83,9 @@ program
     .description('open page and generate code for user actions')
     .option('-o, --output <file name>', 'saves the generated script to a file')
     .option('--target <language>', `language to use, one of javascript, python, python-async, csharp`, process.env.PW_CLI_TARGET_LANG || 'javascript')
+    .option('--electron <electron path>', 'runs the electron executable instead of a browser')
     .action(function(url, command) {
-      codegen(command.parent, url, command.target, command.output);
+      codegen(command.parent, url, command.target, command.output, command.electron);
     }).on('--help', function() {
       console.log('');
       console.log('Examples:');
@@ -338,7 +340,7 @@ async function pdf(options: Options, captureOptions: CaptureOptions, url: string
   await browser.close();
 }
 
-async function codegen(options: Options, url: string | undefined, target: string, outputFile?: string) {
+async function codegen(options: Options, url: string | undefined, target: string, outputFile?: string, electronPath?: string) {
   let languageGenerator: LanguageGenerator;
 
   switch (target) {
@@ -349,7 +351,28 @@ async function codegen(options: Options, url: string | undefined, target: string
     default: throw new Error(`Invalid target: '${target}'`);
   }
 
-  const { context, browserName, launchOptions, contextOptions } = await launchContext(options, false);
+  let context: BrowserContext;
+  let browserName: string;
+  let launchOptions: playwright.LaunchOptions;
+  let contextOptions: playwright.BrowserContextOptions
+  if(electronPath)
+  {  
+    const app = await electron.launch(electronPath, {});
+    context = app.context() as any as BrowserContext;
+    browserName = 'electron';
+    launchOptions = {};
+    contextOptions = {};
+    // TODO: register some sort of close handler to exit the script when electron exits. for some reason page close isn't firing.
+
+    // for some reason, we need to launch something else in order to get left mouse clicks to reach our application. wtf?
+    await playwright.chromium.launch();
+  } else {
+    const launch = await launchContext(options, false);
+    context = launch.context;
+    browserName = launch.browserName;
+    launchOptions = launch.launchOptions;
+    contextOptions = launch.contextOptions;
+  }
 
   if (process.env.PWTRACE)
     contextOptions.recordVideo = { dir: path.join(process.cwd(), '.trace') };
@@ -361,7 +384,10 @@ async function codegen(options: Options, url: string | undefined, target: string
 
   const generator = new CodeGenerator(browserName, launchOptions, contextOptions, output, languageGenerator, options.device);
   new ScriptController(context, generator);
-  await openPage(context, url);
+  if(!electronPath)
+  {
+    await openPage(context, url);
+  }
   if (process.env.PWCLI_EXIT_FOR_TEST)
     await Promise.all(context.pages().map(p => p.close()));
 }

--- a/src/scriptController.ts
+++ b/src/scriptController.ts
@@ -39,6 +39,10 @@ export class ScriptController {
 
   private async _ensureInstalledInFrame(frame: playwright.Frame) {
     try {
+      // don't monitor the devtools window
+      if(frame.page().url().startsWith('devtools://')) {
+        return;
+      }
       const frameAsAny = frame as any;
       await frameAsAny._extendInjectedScript(injectedScriptSource.source, { enableRecorder: !!this._recorder });
     } catch (e) {


### PR DESCRIPTION
This is a quick hack that demonstrates using playwright-cli to support codegen with an electron application.

Assuming your application main process is non-trivial, this demonstration assumes you've already built your electron application with `electron-forge make`.

To use, clone and build this repository, then run with:
`node .\lib\cli.js codegen --electron <Path to build electron executable>`

When completed, you will need to kill the script with ctrl+C, because it does not handle electron exit.

Tested and *kinda* works with electron 10. Does not work with electron 8.

Unfortunately, in order to add playwright-electron as a dependency, electron must also be added as a dependency, which might not be ideal for non-electron use.

Also, for reasons I don't understand yet, when electron is launched, left-clicking the application doesn't work, and neither does keyboard entry. Adding `await playwright.chromium.launch();` to the code seems to fix it, but I have no idea why.

All other arguments or configuration is ignored when using the `--electron` option, except for the electron path.